### PR TITLE
use removeProps and remove wrap

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "styletron-server": "^2.5.7"
   },
   "dependencies": {
-    "styled-system": "1.0.0-5"
+    "styled-system": "1.0.8"
   },
   "peerDependencies": {
     "prop-types": "^15.5.4",

--- a/src/Box.js
+++ b/src/Box.js
@@ -1,17 +1,24 @@
 import React from 'react'
-import { space, width } from 'styled-system'
+import { space, width, removeProps, propTypes } from 'styled-system'
 import styled from './styled'
 
-// hoc to remove unwanted width attribute
-const hoc = Comp => ({width, ...props}) => <Comp {...props} w={width} />
+const CleanDiv = props => {
+  const cleanProps = removeProps(props)
+  return <div {...cleanProps} />
+}
+
+CleanDiv.propTypes = {
+  ...propTypes.width,
+  ...propTypes.wrap,
+}
 
 export const flex = ({flex}) => flex ? {flex} : null
 
-const Box = hoc(styled('div',
+const Box = styled(CleanDiv,
   {boxSizing: 'border-box'},
   width,
   space,
   flex
-))
+)
 
 export default Box

--- a/yarn.lock
+++ b/yarn.lock
@@ -2235,6 +2235,18 @@ faye-websocket@~0.11.0:
   dependencies:
     websocket-driver ">=0.5.1"
 
+fbjs@^0.8.16:
+  version "0.8.16"
+  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.16.tgz#5e67432f550dc41b572bf55847b8aca64e5337db"
+  dependencies:
+    core-js "^1.0.0"
+    isomorphic-fetch "^2.1.1"
+    loose-envify "^1.0.0"
+    object-assign "^4.1.0"
+    promise "^7.1.1"
+    setimmediate "^1.0.5"
+    ua-parser-js "^0.7.9"
+
 fbjs@^0.8.8, fbjs@^0.8.9:
   version "0.8.12"
   resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.12.tgz#10b5d92f76d45575fd63a217d4ea02bea2f8ed04"
@@ -4092,6 +4104,14 @@ prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.8:
     fbjs "^0.8.9"
     loose-envify "^1.3.1"
 
+prop-types@^15.6.0:
+  version "15.6.0"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.0.tgz#ceaf083022fc46b4a35f69e13ef75aed0d639856"
+  dependencies:
+    fbjs "^0.8.16"
+    loose-envify "^1.3.1"
+    object-assign "^4.1.1"
+
 proxy-addr@~1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/proxy-addr/-/proxy-addr-1.1.4.tgz#27e545f6960a44a627d9b44467e35c1b6b4ce2f3"
@@ -4834,9 +4854,11 @@ strip-json-comments@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
 
-styled-system@1.0.0-5:
-  version "1.0.0-5"
-  resolved "https://registry.yarnpkg.com/styled-system/-/styled-system-1.0.0-5.tgz#943a49e5e8d7bd59e29f755eddc59f00efce8632"
+styled-system@1.0.8:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/styled-system/-/styled-system-1.0.8.tgz#a5a08ab26a8cc27e7a22e743d623211b82482b5e"
+  dependencies:
+    prop-types "^15.6.0"
 
 styletron-client@^2.5.7:
   version "2.5.7"


### PR DESCRIPTION
fixed warning with react 16 : 
```
Warning: Received `true` for non-boolean attribute `wrap`. If this is expected, cast the value to a string.
    in div (created by StyledElement)
```

and used removeProps instead of a hoc
